### PR TITLE
add serializer and deserializer of JSBI

### DIFF
--- a/src/model/Position.ts
+++ b/src/model/Position.ts
@@ -1,17 +1,18 @@
 import JSBI from "jsbi";
 import { jsonMember, jsonObject } from "typedjson";
+import { JSBIDeserializer, JSBISerializer } from "../util/Serializer";
 
 @jsonObject
 export class Position {
-  @jsonMember
+  @jsonMember({ deserializer: JSBIDeserializer, serializer: JSBISerializer })
   private _liquidity: JSBI = JSBI.BigInt(0);
-  @jsonMember
+  @jsonMember({ deserializer: JSBIDeserializer, serializer: JSBISerializer })
   private _feeGrowthInside0LastX128: JSBI = JSBI.BigInt(0);
-  @jsonMember
+  @jsonMember({ deserializer: JSBIDeserializer, serializer: JSBISerializer })
   private _feeGrowthInside1LastX128: JSBI = JSBI.BigInt(0);
-  @jsonMember
+  @jsonMember({ deserializer: JSBIDeserializer, serializer: JSBISerializer })
   private _tokensOwed0: JSBI = JSBI.BigInt(0);
-  @jsonMember
+  @jsonMember({ deserializer: JSBIDeserializer, serializer: JSBISerializer })
   private _tokensOwed1: JSBI = JSBI.BigInt(0);
 
   public get liquidity(): JSBI {

--- a/src/model/Tick.ts
+++ b/src/model/Tick.ts
@@ -1,17 +1,18 @@
 import JSBI from "jsbi";
 import { jsonMember, jsonObject } from "typedjson";
+import { JSBIDeserializer, JSBISerializer } from "../util/Serializer";
 
 @jsonObject
 export class Tick {
-  @jsonMember
+  @jsonMember({ deserializer: JSBIDeserializer, serializer: JSBISerializer })
   private _liquidityGross: JSBI = JSBI.BigInt(0);
-  @jsonMember
+  @jsonMember({ deserializer: JSBIDeserializer, serializer: JSBISerializer })
   private _liquidityNet: JSBI = JSBI.BigInt(0);
-  @jsonMember
+  @jsonMember({ deserializer: JSBIDeserializer, serializer: JSBISerializer })
   private _feeGrowthOutside0X128: JSBI = JSBI.BigInt(0);
-  @jsonMember
+  @jsonMember({ deserializer: JSBIDeserializer, serializer: JSBISerializer })
   private _feeGrowthOutside1X128: JSBI = JSBI.BigInt(0);
-  @jsonMember
+  @jsonMember(Boolean)
   private _initialized: boolean = false;
 
   public get liquidityGross(): JSBI {

--- a/src/util/Serializer.ts
+++ b/src/util/Serializer.ts
@@ -1,3 +1,4 @@
+import JSBI from "jsbi";
 import { TypedJSON } from "typedjson";
 import { Constructor } from "typedjson/src/types";
 
@@ -12,3 +13,6 @@ export abstract class Serializer {
     return serializer.parse(json);
   }
 }
+
+export const JSBISerializer = (jsbi: JSBI): string => jsbi.toString();
+export const JSBIDeserializer = (str: string): JSBI => JSBI.BigInt(str);


### PR DESCRIPTION
Note that property with `boolean` need to be given `Boolean` type on `@jsonMember` decorator, or even if we use ReflectDecorators(by import 'reflect-metadata';), `TypedJSON` won't handle this.