### PR TITLE
adding tickManager

### DIFF
--- a/src/manager/TickManager.ts
+++ b/src/manager/TickManager.ts
@@ -106,9 +106,7 @@ export class TickManager {
     feeGrowthGlobal1X128: JSBI
   ): { feeGrowthInside0X128: JSBI; feeGrowthInside1X128: JSBI } {
     assert(
-      this.sortedTicks.has(tickLower) &&
-        this.sortedTicks.has(tickUpper) &&
-        this.sortedTicks.has(tickCurrent),
+      this.sortedTicks.has(tickLower) && this.sortedTicks.has(tickUpper),
       "INVALID_TICK"
     );
     const lower = this.getTickAndInitIfAbsent(tickLower);

--- a/src/manager/TickManager.ts
+++ b/src/manager/TickManager.ts
@@ -1,10 +1,12 @@
-import JSBI from 'jsbi';
+import JSBI from "jsbi";
+import assert from "assert";
 import { Tick } from "../model/Tick";
 import { jsonMapMember, jsonObject } from "typedjson";
 
 @jsonObject
 export class TickManager {
   @jsonMapMember(Number, Tick, { name: "ticks_json" })
+  // key = Tick.tickIndex
   private ticks: Map<number, Tick>;
 
   constructor(ticks: Map<number, Tick> = new Map()) {
@@ -12,15 +14,39 @@ export class TickManager {
   }
 
   get(tickIndex: number): Tick {
-    return this.ticks.get(tickIndex) || new Tick();
+    if (this.ticks.has(tickIndex)) return this.ticks.get(tickIndex)!;
+    const newTick = new Tick(tickIndex);
+    this.set(newTick);
+    return newTick;
   }
 
-  set(tickIndex: number, tick: Tick) {
-    this.ticks.set(tickIndex, tick);
+  set(tick: Tick) {
+    this.ticks.set(tick.tickIndex, tick);
   }
 
-  flipTick(tickIndex: number, tickSpacing: number) {
-    // TODO
+  private nextInitializedTick(
+    sortedTicks: readonly Tick[],
+    tick: number,
+    leftToRight: boolean
+  ): Tick {
+    if (leftToRight) {
+      assert(!this.isBelowSmallest(sortedTicks, tick), "BELOW_SMALLEST");
+      if (this.isAtOrAboveLargest(sortedTicks, tick)) {
+        return sortedTicks[sortedTicks.length - 1];
+      }
+      const index = this.binarySearch(sortedTicks, tick);
+      return sortedTicks[index];
+    } else {
+      assert(
+        !this.isAtOrAboveLargest(sortedTicks, tick),
+        "AT_OR_ABOVE_LARGEST"
+      );
+      if (this.isBelowSmallest(sortedTicks, tick)) {
+        return sortedTicks[0];
+      }
+      const index = this.binarySearch(sortedTicks, tick);
+      return sortedTicks[index + 1];
+    }
   }
 
   getNextInitializedTick(
@@ -28,8 +54,40 @@ export class TickManager {
     tickSpacing: number,
     leftToRight: boolean
   ): { nextTick: number; initialized: boolean } {
-    // TODO
-    return { nextTick: 0, initialized: false };
+    const sortedTicks = this.getSortedTicks();
+    const compressed = Math.floor(tick / tickSpacing); // matches rounding in the code
+
+    if (leftToRight) {
+      const wordPos = compressed >> 8;
+      const minimum = (wordPos << 8) * tickSpacing;
+
+      if (this.isBelowSmallest(sortedTicks, tick)) {
+        return { nextTick: minimum, initialized: false };
+      }
+
+      const index = this.nextInitializedTick(sortedTicks, tick, leftToRight)
+        .tickIndex;
+      const nextInitializedTick = Math.max(minimum, index);
+      return {
+        nextTick: nextInitializedTick,
+        initialized: nextInitializedTick === index,
+      };
+    } else {
+      const wordPos = (compressed + 1) >> 8;
+      const maximum = ((wordPos + 1) << 8) * tickSpacing - 1;
+
+      if (this.isAtOrAboveLargest(sortedTicks, tick)) {
+        return { nextTick: maximum, initialized: false };
+      }
+
+      const index = this.nextInitializedTick(sortedTicks, tick, leftToRight)
+        .tickIndex;
+      const nextInitializedTick = Math.min(maximum, index);
+      return {
+        nextTick: nextInitializedTick,
+        initialized: nextInitializedTick === index,
+      };
+    }
   }
 
   getFeeGrowthInside(
@@ -37,10 +95,96 @@ export class TickManager {
     tickUpper: number,
     tickCurrent: number,
     feeGrowthGlobal0X128: JSBI,
-    feeGrowthGlobal1X128: JSBI,
-    leftToRight: boolean
-  ): JSBI {
-    // TODO
-    return JSBI.BigInt(0);
+    feeGrowthGlobal1X128: JSBI
+  ): { feeGrowthInside0X128: JSBI; feeGrowthInside1X128: JSBI } {
+    const lower = this.get(tickLower);
+    const upper = this.get(tickUpper);
+    let feeGrowthBelow0X128: JSBI;
+    let feeGrowthBelow1X128: JSBI;
+    if (tickCurrent >= tickLower) {
+      feeGrowthBelow0X128 = lower.feeGrowthOutside0X128;
+      feeGrowthBelow1X128 = lower.feeGrowthOutside1X128;
+    } else {
+      feeGrowthBelow0X128 = JSBI.subtract(
+        feeGrowthGlobal0X128,
+        lower.feeGrowthOutside0X128
+      );
+      feeGrowthBelow1X128 = JSBI.subtract(
+        feeGrowthGlobal1X128,
+        lower.feeGrowthOutside1X128
+      );
+    }
+
+    let feeGrowthAbove0X128: JSBI;
+    let feeGrowthAbove1X128: JSBI;
+    if (tickCurrent < tickUpper) {
+      feeGrowthAbove0X128 = upper.feeGrowthOutside0X128;
+      feeGrowthAbove1X128 = upper.feeGrowthOutside1X128;
+    } else {
+      feeGrowthAbove0X128 = JSBI.subtract(
+        feeGrowthGlobal0X128,
+        upper.feeGrowthOutside0X128
+      );
+      feeGrowthAbove1X128 = JSBI.subtract(
+        feeGrowthGlobal1X128,
+        upper.feeGrowthOutside1X128
+      );
+    }
+    return {
+      feeGrowthInside0X128: JSBI.subtract(
+        JSBI.subtract(feeGrowthGlobal0X128, feeGrowthBelow0X128),
+        feeGrowthAbove0X128
+      ),
+      feeGrowthInside1X128: JSBI.subtract(
+        JSBI.subtract(feeGrowthGlobal1X128, feeGrowthBelow1X128),
+        feeGrowthAbove1X128
+      ),
+    };
+  }
+
+  clear(tick: number) {
+    this.ticks.delete(tick);
+  }
+
+  private getSortedTicks(): Tick[] {
+    const sortedTicks = new Map([...this.ticks.entries()].sort());
+    return Array.from(sortedTicks.values());
+  }
+
+  private isBelowSmallest(sortedTicks: readonly Tick[], tick: number): boolean {
+    assert(sortedTicks.length > 0, "LENGTH");
+    return tick < sortedTicks[0].tickIndex;
+  }
+
+  private isAtOrAboveLargest(
+    sortedTicks: readonly Tick[],
+    tick: number
+  ): boolean {
+    assert(sortedTicks.length > 0, "LENGTH");
+    return tick >= sortedTicks[sortedTicks.length - 1].tickIndex;
+  }
+
+  private binarySearch(sortedTicks: readonly Tick[], tick: number): number {
+    assert(!this.isBelowSmallest(sortedTicks, tick), "BELOW_SMALLEST");
+
+    let l = 0;
+    let r = sortedTicks.length - 1;
+    let i;
+    while (true) {
+      i = Math.floor((l + r) / 2);
+
+      if (
+        sortedTicks[i].tickIndex <= tick &&
+        (i === sortedTicks.length - 1 || sortedTicks[i + 1].tickIndex > tick)
+      ) {
+        return i;
+      }
+
+      if (sortedTicks[i].tickIndex < tick) {
+        l = i + 1;
+      } else {
+        r = i - 1;
+      }
+    }
   }
 }

--- a/src/model/Tick.ts
+++ b/src/model/Tick.ts
@@ -56,7 +56,7 @@ export class Tick {
     tickCurrent: number,
     feeGrowthGlobal0X128: JSBI,
     feeGrowthGlobal1X128: JSBI,
-    leftToRight: boolean
+    upper: boolean
   ): boolean {
     const liquidityGrossBefore = this.liquidityGross;
     const liquidityGrossAfter = LiquidityMath.addDelta(
@@ -74,7 +74,7 @@ export class Tick {
       }
     }
     this._liquidityGross = liquidityGrossAfter;
-    this._liquidityNet = leftToRight
+    this._liquidityNet = upper
       ? JSBI.subtract(this._liquidityNet, liquidityDelta)
       : JSBI.add(this._liquidityNet, liquidityDelta);
     return flipped;

--- a/src/util/LiquidityMath.ts
+++ b/src/util/LiquidityMath.ts
@@ -1,10 +1,13 @@
 import JSBI from "jsbi";
 import { NEGATIVE_ONE, ZERO } from "../enum/InternalConstants";
+import assert from "assert";
 
 export abstract class LiquidityMath {
   static addDelta(x: JSBI, y: JSBI): JSBI {
     if (JSBI.lessThan(y, ZERO)) {
-      return JSBI.subtract(x, JSBI.multiply(y, NEGATIVE_ONE));
+      const negatedY = JSBI.multiply(y, NEGATIVE_ONE);
+      assert(JSBI.greaterThanOrEqual(x, negatedY), "UNDERFLOW");
+      return JSBI.subtract(x, negatedY);
     } else {
       return JSBI.add(x, y);
     }


### PR DESCRIPTION
- added `clear()` which needs to be called when `liquidityGross` approaches zero
- removed `flipTick()` since `bitmap` is not being used to manage tick positions, and there is no `initialized` bit to flip
- the `initialized` property in each `Tick` is no longer a separate `boolean` value, we are using the equivalent: `liquidityGross != 0` to avoid the out-of-sync issue when tracking the same value in 2 different places 

Please have a look!
Thanks!
